### PR TITLE
keyword(getExtendedRegionFrom) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ target
 *.iml
 teste
 .vscode
+.classpath
+.project
+.settings/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ class
 dist
 target
 *.iml
+teste
+.vscode

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>com.sikulix</groupId>
             <artifactId>sikulixapi</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.4</version>
         </dependency>
         <!--dependency>
             <groupId>org.robotframework</groupId>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>com.sikulix</groupId>
             <artifactId>${sikulix.libs}</artifactId>
-            <version>1.1.1</version>
+            <version>1.1.4</version>
         </dependency>
 
     </dependencies>
@@ -205,7 +205,7 @@
                                 <echo message="unzip package"/>
                                 <unzip src="target/SikuliLibrary.zip" dest="target/src"/>
                                 <echo message="generate keywords.py"/>
-                                <exec dir="target/src" executable="python3" failonerror="true">
+                                <exec dir="target/src" executable="python" failonerror="true">
                                     <arg line="-m SikuliLibrary.__init__"/>
                                 </exec>
                                 <!--<unzip src="output/inner.zip" dest="output" />-->

--- a/src/java/com/github/rainmanwy/robotframework/sikulilib/keywords/ScreenKeywords.java
+++ b/src/java/com/github/rainmanwy/robotframework/sikulilib/keywords/ScreenKeywords.java
@@ -545,7 +545,6 @@ public class ScreenKeywords {
     @ArgumentNames({"image="})
     public String getText() throws Exception {
         return screen.text();
-
     }
 
     @RobotKeywordOverload
@@ -665,18 +664,19 @@ public class ScreenKeywords {
 
     @RobotKeyword("Get extended region from" + 
                 "\n Extended the given image creating a region above or below with the same width" + 
-                "\n The height can change using the multiplier @number_of_times_to_repeat, if 2 is given the new region will have twice the height of the orignal ")
+                "\n The height can change using the multiplier @number_of_times_to_repeat, if 2 is given the new region will have twice the height of the orignalge ")
     @ArgumentNames({"image", "direction", "number_of_times_to_repeat"})
-    public Region getExtendedRegionFrom(String image, String direction, int number_of_times_to_repeat) throws Exception {
+    public int[] getExtendedRegionFrom(String image, String direction, int number_of_times_to_repeat) throws Exception {
+        
         Match match = null;
         try{
             match = screen.find(image);
             Region new_region = new Region(match);
             int height = new_region.h;
             int width = new_region.w;
-            //match.highlight(2);
-            
+                        
             Region r = null;
+            int [] result = new int[4];
             if (direction.equals("below")){
                 r = new_region.below(height * number_of_times_to_repeat);
                 r.highlight(1);
@@ -685,16 +685,45 @@ public class ScreenKeywords {
                 r = new_region.above(height * number_of_times_to_repeat);
                 r.highlight(1);
             }
+            else if(direction.equals("left")){
+                r = new_region.left(height * number_of_times_to_repeat);
+            }
+            else if(direction.equals("right")){
+                r = new_region.right(height * number_of_times_to_repeat);
+            }
             else{
                 r = new_region;
             }
-
-            return r;
+            System.out.println(r);
+            result[0] = r.x;
+            result[1] = r.y;
+            result[2] = r.w;
+            result[3] = r.h;
+            return result;
         }
         catch (FindFailed e) {
             capture();
             throw new ScreenOperationException("Extended image "+image+" failed" + e.getMessage(), e);    
         }
        
+    }
+
+    @RobotKeyword("Read text from given region")
+    @ArgumentNames({"reg"})
+    public String readTextFromRegion(ArrayList<Object> reg){
+        System.out.println("reg variable: " + reg);
+        
+        int x = Integer.parseInt(reg.get(0).toString());
+        int y = Integer.parseInt(reg.get(1).toString()); 
+        int w = Integer.parseInt(reg.get(2).toString()); 
+        int h = Integer.parseInt(reg.get(3).toString()); 
+        
+        Region region = new Region(x,y,w,h);
+        if(region != null){
+            return region.text();
+        }else{
+            System.out.println("error region test: " + reg);
+            return "ERROR";
+        }
     }
 }

--- a/src/java/com/github/rainmanwy/robotframework/sikulilib/keywords/ScreenKeywords.java
+++ b/src/java/com/github/rainmanwy/robotframework/sikulilib/keywords/ScreenKeywords.java
@@ -663,4 +663,38 @@ public class ScreenKeywords {
         return screen.getID();
     }
 
+    @RobotKeyword("Get extended region from" + 
+                "\n Extended the given image creating a region above or below with the same width" + 
+                "\n The height can change using the multiplier @number_of_times_to_repeat, if 2 is given the new region will have twice the height of the orignal ")
+    @ArgumentNames({"image", "direction", "number_of_times_to_repeat"})
+    public Region getExtendedRegionFrom(String image, String direction, int number_of_times_to_repeat) throws Exception {
+        Match match = null;
+        try{
+            match = screen.find(image);
+            Region new_region = new Region(match);
+            int height = new_region.h;
+            int width = new_region.w;
+            //match.highlight(2);
+            
+            Region r = null;
+            if (direction.equals("below")){
+                r = new_region.below(height * number_of_times_to_repeat);
+                r.highlight(1);
+            }
+            else if(direction.equals("above")){
+                r = new_region.above(height * number_of_times_to_repeat);
+                r.highlight(1);
+            }
+            else{
+                r = new_region;
+            }
+
+            return r;
+        }
+        catch (FindFailed e) {
+            capture();
+            throw new ScreenOperationException("Extended image "+image+" failed" + e.getMessage(), e);    
+        }
+       
+    }
 }


### PR DESCRIPTION
It returns a region extended from the original given image, with the same width, using two arguments: the direction (below, above) and a multiplier to specify how big height grows. If multiplier set to "1" and direction to "above",  the newly created region will have the same size (width, height) as the original and will be placed right above it.

I'm still testing and writing it, making the PR to let it be know.
It would be cool if upgrade the sikulixapi to 1.1.4, but I don't know maven to do it.